### PR TITLE
fix: replace hardcoded /Users/deji paths with portable home dir variables

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -10,7 +10,7 @@
 	status = auto
 	branch = auto
 [core]
-	excludesfile = /Users/deji/.gitignore
+	excludesfile = ~/.gitignore
 	autocrlf = input
 [filter "lfs"]
 	smudge = git-lfs smudge -- %f
@@ -18,7 +18,7 @@
 	required = true
 	clean = git-lfs clean -- %f
 [commit]
-	template = /Users/deji/.stCommitMsg
+	template = ~/.stCommitMsg
 [init]
 	defaultBranch = main
 [alias]

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,8 +1,8 @@
 . "$HOME/.cargo/env"
 
 # zerobrew
-export ZEROBREW_DIR=/Users/deji/.zerobrew
-export ZEROBREW_BIN=/Users/deji/.zerobrew/bin
+export ZEROBREW_DIR="$HOME/.zerobrew"
+export ZEROBREW_BIN="$HOME/.zerobrew/bin"
 export ZEROBREW_ROOT=/opt/zerobrew
 export ZEROBREW_PREFIX=/opt/zerobrew/prefix
 export PKG_CONFIG_PATH="$ZEROBREW_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -68,7 +68,7 @@ preexec() {
 autoload -U +X bashcompinit && bashcompinit
 complete -o nospace -C /usr/local/bin/terraform terraform
 
-[ -f "/Users/deji/.ghcup/env" ] && source "/Users/deji/.ghcup/env" # ghcup-env
+[ -f "$HOME/.ghcup/env" ] && source "$HOME/.ghcup/env" # ghcup-env
 [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"  # This loads nvm
 [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
 


### PR DESCRIPTION
Replaces hardcoded `/Users/deji` paths with portable equivalents so the dotfiles can be installed on any machine regardless of the home directory path.

- `.gitconfig`: `excludesfile` and `commit.template` now use `~` (git natively expands this)
- `zsh/.zshenv`: `ZEROBREW_DIR` and `ZEROBREW_BIN` now use `$HOME`
- `zsh/.zshrc`: ghcup env source now uses `$HOME`